### PR TITLE
2 oauth and rachio api setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /log/*
 !/log/.keep
 /tmp
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'react-rails'
 gem 'rails_12factor', group: :production
 
 group :development, :test do
+  gem 'webmock'
   gem 'byebug'
   gem 'mocha'
   gem 'vcr'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'react-rails'
 gem 'rails_12factor', group: :production
 
 group :development, :test do
-  gem 'webmock'
   gem 'byebug'
   gem 'mocha'
   gem 'vcr'
@@ -25,6 +24,10 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 3.1'
+end
+
+group :test do
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     daemons (1.2.3)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -77,6 +79,7 @@ GEM
       thor (~> 0.14)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.0)
     i18n (0.7.0)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
@@ -171,6 +174,7 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     rubyzip (1.2.0)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -213,6 +217,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (1.24.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket (1.2.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -247,6 +255,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   web-console (~> 2.0)
+  webmock
 
 BUNDLED WITH
    1.11.2

--- a/app/assets/javascripts/components/_body.js.jsx
+++ b/app/assets/javascripts/components/_body.js.jsx
@@ -3,7 +3,7 @@ var Body = React.createClass({
     this.setState(state);
   },
 
-  loggedIn(){
+  dashboardOrLogin(){
     if(this.props.user){
       return <RachioDashboard
                 user={this.props.user}
@@ -20,7 +20,7 @@ var Body = React.createClass({
   render() {
     return (
       <div>
-        {this.loggedIn()}
+        {this.dashboardOrLogin()}
       </div>
     );
   }

--- a/app/assets/javascripts/components/_body.js.jsx
+++ b/app/assets/javascripts/components/_body.js.jsx
@@ -1,24 +1,25 @@
 var Body = React.createClass({
-  getInitialState(){
-    return {message: ""};
-  },
-
   setBodyState(state){
     this.setState(state);
   },
 
   loggedIn(){
     if(this.props.user){
-      return <RachioDashboard logout={this.props.logout}/>;
+      return <RachioDashboard
+                user={this.props.user}
+                logout={this.props.logout}
+             />;
     } else {
-      return <Login login={this.props.login} setBodyState={this.setBodyState}/>;
+      return <Login
+                login={this.props.login}
+                setBodyState={this.setBodyState}
+             />;
     }
   },
 
   render() {
     return (
       <div>
-        {this.state.message}
         {this.loggedIn()}
       </div>
     );

--- a/app/assets/javascripts/components/_device.js.jsx
+++ b/app/assets/javascripts/components/_device.js.jsx
@@ -1,0 +1,20 @@
+var Device = React.createClass({
+  getInitialState(){
+    return {zones: this.createZoneComponents(this.props.device)};
+  },
+
+  createZoneComponents(device){
+    return device.zones.map((zone) => {
+      return <Zone key={zone.rachio_zone_id} zone={zone}/>;
+    });
+  },
+
+  render() {
+    return (
+      <div>
+        <h3>Device ID {this.props.device.rachio_device_id}</h3>
+        {this.state.zones}
+      </div>
+    );
+  }
+});

--- a/app/assets/javascripts/components/_login.js.jsx
+++ b/app/assets/javascripts/components/_login.js.jsx
@@ -7,8 +7,8 @@ var Login = React.createClass({
       type: 'POST',
       data: { user: { username: username, password: password } },
       success: (reply) => {
+        debugger
         this.props.login(reply.user);
-        // this.updateUserInfo();
       },
       error: (reply) => {
         this.props.login(reply);

--- a/app/assets/javascripts/components/_login.js.jsx
+++ b/app/assets/javascripts/components/_login.js.jsx
@@ -7,7 +7,6 @@ var Login = React.createClass({
       type: 'POST',
       data: { user: { username: username, password: password } },
       success: (reply) => {
-        debugger
         this.props.login(reply.user);
       },
       error: (reply) => {
@@ -15,19 +14,6 @@ var Login = React.createClass({
       }
     });
   },
-
-  // updateUserInfo(){
-  //   $.ajax({
-  //     url: '/api/v1/user',
-  //     type: 'GET',
-  //     success: (reply) => {
-  //       this.props.login(reply.user);
-  //     },
-  //     error: (reply) => {
-  //       this.props.login(reply);
-  //     }
-  //   });
-  // },
 
   render() {
     return (

--- a/app/assets/javascripts/components/_login.js.jsx
+++ b/app/assets/javascripts/components/_login.js.jsx
@@ -8,6 +8,20 @@ var Login = React.createClass({
       data: { user: { username: username, password: password } },
       success: (reply) => {
         this.props.login(reply.user);
+        this.updateUserInfo();
+      },
+      error: (reply) => {
+        this.props.login(reply);
+      }
+    });
+  },
+
+  updateUserInfo(){
+    $.ajax({
+      url: '/api/v1/user',
+      type: 'GET',
+      success: (reply) => {
+        this.props.login(reply.user);
       },
       error: (reply) => {
         this.props.login(reply);

--- a/app/assets/javascripts/components/_login.js.jsx
+++ b/app/assets/javascripts/components/_login.js.jsx
@@ -8,7 +8,7 @@ var Login = React.createClass({
       data: { user: { username: username, password: password } },
       success: (reply) => {
         this.props.login(reply.user);
-        this.updateUserInfo();
+        // this.updateUserInfo();
       },
       error: (reply) => {
         this.props.login(reply);
@@ -16,18 +16,18 @@ var Login = React.createClass({
     });
   },
 
-  updateUserInfo(){
-    $.ajax({
-      url: '/api/v1/user',
-      type: 'GET',
-      success: (reply) => {
-        this.props.login(reply.user);
-      },
-      error: (reply) => {
-        this.props.login(reply);
-      }
-    });
-  },
+  // updateUserInfo(){
+  //   $.ajax({
+  //     url: '/api/v1/user',
+  //     type: 'GET',
+  //     success: (reply) => {
+  //       this.props.login(reply.user);
+  //     },
+  //     error: (reply) => {
+  //       this.props.login(reply);
+  //     }
+  //   });
+  // },
 
   render() {
     return (

--- a/app/assets/javascripts/components/_main.js.jsx
+++ b/app/assets/javascripts/components/_main.js.jsx
@@ -3,10 +3,6 @@ var Main = React.createClass({
     return {user: this.props.user, message: this.props.message};
   },
 
-  componentWillMount(){
-
-  },
-
   logout(){
     this.setState({user: undefined, message: "Logged out"});
   },

--- a/app/assets/javascripts/components/_main.js.jsx
+++ b/app/assets/javascripts/components/_main.js.jsx
@@ -9,7 +9,7 @@ var Main = React.createClass({
 
   login(user){
     if(user.username){
-      this.setState({user: {username: user.username}, message: "Logged in as " + user.username});
+      this.setState({user: user, message: "Logged in as " + user.username});
     } else {
       this.setState({message: user.responseText});
     }
@@ -19,7 +19,11 @@ var Main = React.createClass({
     return (
       <div>
         <Header message={this.state.message}/>
-        <Body logout={this.logout} login={this.login} user={this.state.user}/>
+        <Body
+          logout={this.logout}
+          login={this.login}
+          user={this.state.user}
+        />
       </div>
     );
   }

--- a/app/assets/javascripts/components/_rachioDashboard.js.jsx
+++ b/app/assets/javascripts/components/_rachioDashboard.js.jsx
@@ -1,4 +1,14 @@
 var RachioDashboard = React.createClass({
+  getInitialState(){
+    return {devices: this.createDeviceComponents(this.props.user)};
+  },
+
+  createDeviceComponents(user){
+    return user.devices.map((device) => {
+      return <Device key={device.rachio_device_id} device={device}/>;
+    });
+  },
+
   handleLogout(){
     $.ajax({
       url: '/api/v1/login',
@@ -15,6 +25,7 @@ var RachioDashboard = React.createClass({
   render() {
     return (
       <div>
+        {this.state.devices}
         <button onClick={this.handleLogout}>Logout</button>
       </div>
     );

--- a/app/assets/javascripts/components/_zone.js.jsx
+++ b/app/assets/javascripts/components/_zone.js.jsx
@@ -1,0 +1,13 @@
+var Zone = React.createClass({
+  getInitialState(){
+    return {};
+  },
+
+  render() {
+    return (
+      <div>
+        {this.props.zone.name}
+      </div>
+    );
+  }
+});

--- a/app/controllers/api/v1/rachio_controller.rb
+++ b/app/controllers/api/v1/rachio_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Controller < ApplicationController
+
+  def method_name
+
+  end
+
+end

--- a/app/controllers/api/v1/rachio_controller.rb
+++ b/app/controllers/api/v1/rachio_controller.rb
@@ -1,7 +1,0 @@
-class Api::V1::Controller < ApplicationController
-
-  def method_name
-
-  end
-
-end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::SessionsController < ApplicationController
   def create
     user = User.find_by(username: params["user"]["username"])
     if user && user.authenticate(params[:user][:password])
+      ras = RachioApiService.new(user)
       session[:user_id] = user.id
       render json: {user: {username: user.username}}
     else

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::SessionsController < ApplicationController
   end
 
   def destroy
+    current_user.devices.destroy_all
     session[:user_id] = nil
     response.status = 204
     render json: ""

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -2,7 +2,6 @@ class Api::V1::SessionsController < ApplicationController
   def create
     user = User.find_by(username: params["user"]["username"])
     if user && user.authenticate(params[:user][:password])
-      ras = RachioApiService.new(user)
       session[:user_id] = user.id
       render json: {user: {username: user.username}}
     else

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -3,7 +3,8 @@ class Api::V1::SessionsController < ApplicationController
     user = User.find_by(username: params["user"]["username"])
     if user && user.authenticate(params[:user][:password])
       session[:user_id] = user.id
-      render json: {user: {username: user.username}}
+      current_user.get_or_update_devices(current_users_rachio_api_service)
+      render json: current_user_dom
     else
       response.status = 400
       render json: "No user with given username and password found"

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::UsersController < ApplicationController
 
   def show
-    current_user.get_or_update_devices(current_users_rachio_api_service)
+    # current_user.get_or_update_devices(current_users_rachio_api_service)
   end
-
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,0 @@
-class Api::V1::UsersController < ApplicationController
-
-  def show
-    # current_user.get_or_update_devices(current_users_rachio_api_service)
-  end
-end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::UsersController < ApplicationController
+
+  def show
+    current_user.get_or_update_devices(current_users_rachio_api_service)
+  end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::Base
     User.find(session[:user_id]) if session[:user_id]
   end
 
-  def rachio_api_service
-    RachioApiService.new(current_user.api_key) if current_user
+  def current_users_rachio_api_service
+    RachioApiService.new(current_user) if current_user
   end
 
   def current_user_dom

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,11 @@ class ApplicationController < ActionController::Base
   def current_user_dom
     if current_user
       name = current_user.username
-      {user: {username: name}, message: "Logged in as #{name}"}
+      {
+        user: {username: name},
+        message: "Logged in as #{name}",
+        legal_api_key: current_users_rachio_api_service.legal_api_key?
+      }
     else
       {}
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::Base
     User.find(session[:user_id]) if session[:user_id]
   end
 
+  def rachio_api_service
+    RachioApiService.new(current_user.api_key) if current_user
+  end
+
   def current_user_dom
     if current_user
       name = current_user.username

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,7 @@ class ApplicationController < ActionController::Base
 
   def current_user_dom
     if current_user
-      name = current_user.username
-      {
-        user: {username: name},
-        message: "Logged in as #{name}",
-        legal_api_key: current_users_rachio_api_service.legal_api_key?
-      }
+      current_user.dom_format
     else
       {}
     end

--- a/app/controllers/rachio_controller.rb
+++ b/app/controllers/rachio_controller.rb
@@ -1,6 +1,4 @@
 class RachioController < ApplicationController
-
   def index
   end
-  
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,6 +1,6 @@
 class Device < ActiveRecord::Base
   belongs_to :user
-  has_many :zones
+  has_many :zones, dependent: :destroy
 
   def dom_format
     dom_zones = zones.map do |zone|

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,4 +1,17 @@
 class Device < ActiveRecord::Base
   belongs_to :user
   has_many :zones
+
+  def dom_format
+    dom_zones = zones.map do |zone|
+      zone.dom_format
+    end
+
+    {
+      rachio_device_id: rachio_device_id,
+      status: status,
+      on: on,
+      zones: dom_zones
+    }
+  end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,0 +1,4 @@
+class Device < ActiveRecord::Base
+  belongs_to :user
+  has_many :zones
+end

--- a/app/models/device_loader.rb
+++ b/app/models/device_loader.rb
@@ -1,5 +1,8 @@
 module DeviceLoader
-  def load_devices(user, devices_json)
+  def load_devices(rachio_api_service)
+    devices_json = rachio_api_service.get_user_devices
+    user = rachio_api_service.user
+    binding.pry
     devices_json.each do |device|
       db_device = user.devices.find_or_create_by(rachio_device_id: device["id"])
       db_device.status = device["status"]
@@ -12,7 +15,8 @@ module DeviceLoader
 
   def load_zones(db_device, zones_json)
     zones_json.each do |zone|
-      db_zone = db_device.find_or_create_by(rachio_zone_id: zone["id"])
+      db_zone = db_device.zones.find_or_create_by(rachio_zone_id: zone["id"])
+      binding.pry
       db_zone.zone_number = zone["zoneNumber"]
       db_zone.name = zone["name"]
       db_zone.enabled = zone["enabled"]

--- a/app/models/device_loader.rb
+++ b/app/models/device_loader.rb
@@ -2,7 +2,6 @@ module DeviceLoader
   def load_devices(rachio_api_service)
     devices_json = rachio_api_service.get_user_devices
     user = rachio_api_service.user
-    binding.pry
     devices_json.each do |device|
       db_device = user.devices.find_or_create_by(rachio_device_id: device["id"])
       db_device.status = device["status"]
@@ -11,12 +10,12 @@ module DeviceLoader
       load_zones(db_device, device["zones"])
       db_device.save
     end
+    :ok
   end
 
   def load_zones(db_device, zones_json)
     zones_json.each do |zone|
       db_zone = db_device.zones.find_or_create_by(rachio_zone_id: zone["id"])
-      binding.pry
       db_zone.zone_number = zone["zoneNumber"]
       db_zone.name = zone["name"]
       db_zone.enabled = zone["enabled"]

--- a/app/models/device_loader.rb
+++ b/app/models/device_loader.rb
@@ -1,0 +1,22 @@
+module DeviceLoader
+  def load_devices(user, devices_json)
+    devices_json.each do |device|
+      db_device = user.devices.find_or_create_by(rachio_device_id: device["id"])
+      db_device.status = device["status"]
+      db_device.on = device["on"]
+      db_device.name = device["name"]
+      load_zones(db_device, device["zones"])
+      db_device.save
+    end
+  end
+
+  def load_zones(db_device, zones_json)
+    zones_json.each do |zone|
+      db_zone = db_device.find_or_create_by(rachio_zone_id: zone["id"])
+      db_zone.zone_number = zone["zoneNumber"]
+      db_zone.name = zone["name"]
+      db_zone.enabled = zone["enabled"]
+      db_zone.save
+    end
+  end
+end

--- a/app/models/rachio_api_service.rb
+++ b/app/models/rachio_api_service.rb
@@ -1,0 +1,36 @@
+class RachioApiService
+  attr_reader :api_key, :root_url, :user_rachio_id
+
+  def initialize(user)
+    @api_key = user.api_key
+    @root_url = "https://api.rach.io/1/public"
+    @user_rachio_id = user.rachio_id ||= get_user_rachio_id
+  end
+
+  def get_user_rachio_id
+    get("/person/info")["id"]
+  end
+
+  def get_user_devices
+    get("/person/#{user_rachio_id}")["devices"]
+  end
+
+  def get(path)
+    uri = URI(root_url + path)
+    req = Net::HTTP::Get.new(uri, "Authorization" => "Bearer #{api_key}")
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") {|http|
+      http.request(req)
+    }
+    JSON.parse(res.body)
+  end
+
+  def put(path, post_body)
+    uri = URI(root_url + path + "/")
+    req = Net::HTTP::Post.new(uri, "Authorization" => "Bearer #{api_key}")
+    req.body = post_body
+    res = Net::HTTP.start(uri.hostname, uri.port) {|http|
+      http.request(req)
+    }
+    JSON.parse(res.body)
+  end
+end

--- a/app/models/rachio_api_service.rb
+++ b/app/models/rachio_api_service.rb
@@ -9,12 +9,17 @@ class RachioApiService
   end
 
   def get_or_update_user_rachio_id
-    user.update_attribute(:rachio_id, get("/person/info")["id"])
+    user.rachio_id = get("/person/info")["id"]
+    user.save
     user.rachio_id
   end
 
   def get_user_devices
     get("/person/#{user_rachio_id}")["devices"]
+  end
+
+  def legal_api_key?
+    user_rachio_id
   end
 
   def get(path)

--- a/app/models/rachio_api_service.rb
+++ b/app/models/rachio_api_service.rb
@@ -1,14 +1,16 @@
 class RachioApiService
-  attr_reader :api_key, :root_url, :user_rachio_id
+  attr_reader :api_key, :root_url, :user_rachio_id, :user
 
   def initialize(user)
+    @user = user
     @api_key = user.api_key
     @root_url = "https://api.rach.io/1/public"
-    @user_rachio_id = user.rachio_id ||= get_user_rachio_id
+    @user_rachio_id = get_or_update_user_rachio_id
   end
 
-  def get_user_rachio_id
-    get("/person/info")["id"]
+  def get_or_update_user_rachio_id
+    user.update_attribute(:rachio_id, get("/person/info")["id"])
+    user.rachio_id
   end
 
   def get_user_devices
@@ -24,13 +26,13 @@ class RachioApiService
     JSON.parse(res.body)
   end
 
-  def put(path, post_body)
-    uri = URI(root_url + path + "/")
-    req = Net::HTTP::Post.new(uri, "Authorization" => "Bearer #{api_key}")
-    req.body = post_body
-    res = Net::HTTP.start(uri.hostname, uri.port) {|http|
-      http.request(req)
-    }
-    JSON.parse(res.body)
-  end
+  # def put(path, post_body)
+  #   uri = URI(root_url + path + "/")
+  #   req = Net::HTTP::Post.new(uri, "Authorization" => "Bearer #{api_key}")
+  #   req.body = post_body
+  #   res = Net::HTTP.start(uri.hostname, uri.port) {|http|
+  #     http.request(req)
+  #   }
+  #   JSON.parse(res.body)
+  # end
 end

--- a/app/models/rachio_api_service.rb
+++ b/app/models/rachio_api_service.rb
@@ -30,14 +30,4 @@ class RachioApiService
     }
     JSON.parse(res.body)
   end
-
-  # def put(path, post_body)
-  #   uri = URI(root_url + path + "/")
-  #   req = Net::HTTP::Post.new(uri, "Authorization" => "Bearer #{api_key}")
-  #   req.body = post_body
-  #   res = Net::HTTP.start(uri.hostname, uri.port) {|http|
-  #     http.request(req)
-  #   }
-  #   JSON.parse(res.body)
-  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include DeviceLoader
   has_secure_password
-  has_many :devices
+  has_many :devices, dependent: :destroy
 
   def get_or_update_devices(rachio_api_service)
     if rachio_api_service.legal_api_key?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ActiveRecord::Base
+  include DeviceLoader
   has_secure_password
 
-  def find_or_update_devices
-    
+  def get_or_update_devices(rachio_api_service)
+    load_devices(self, rachio_api_service.get_user_devices)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,14 @@ class User < ActiveRecord::Base
     end
   end
 
-  # def format_device_info
-  #   devices.map do |device|
-  #
-  #   end
-  # end
+  def dom_format
+    dom_devices = devices.map do |device|
+      device.dom_format
+    end
+
+    {
+      user: {username: username, devices: dom_devices},
+      message: "Logged in as #{username}",
+    }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,17 @@
 class User < ActiveRecord::Base
   include DeviceLoader
   has_secure_password
+  has_many :devices
 
   def get_or_update_devices(rachio_api_service)
-    load_devices(self, rachio_api_service.get_user_devices)
+    if rachio_api_service.legal_api_key?
+      load_devices(rachio_api_service)
+    end
   end
+
+  # def format_device_info
+  #   devices.map do |device|
+  #
+  #   end
+  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_password
+
+  def find_or_update_devices
+    
+  end
 end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,0 +1,3 @@
+class Zone < ActiveRecord::Base
+  belongs_to :device
+end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,3 +1,12 @@
 class Zone < ActiveRecord::Base
   belongs_to :device
+
+  def dom_format
+    {
+      rachio_zone_id: rachio_zone_id,
+      zoneNumber: zone_number,
+      enabled: enabled,
+      name: name
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post 'login' => 'sessions#create'
       delete 'login' => 'sessions#destroy'
+      resource :user, only: [:show]
     end
   end
 end

--- a/db/migrate/20160509004155_add_rachio_id_to_users.rb
+++ b/db/migrate/20160509004155_add_rachio_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddRachioIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :rachio_id, :string
+  end
+end

--- a/db/migrate/20160509185849_create_devices.rb
+++ b/db/migrate/20160509185849_create_devices.rb
@@ -1,0 +1,13 @@
+class CreateDevices < ActiveRecord::Migration
+  def change
+    create_table :devices do |t|
+      t.string :rachio_device_id
+      t.string :status
+      t.boolean :on
+      t.string :name
+      t.references :user, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160509190203_create_zones.rb
+++ b/db/migrate/20160509190203_create_zones.rb
@@ -1,0 +1,13 @@
+class CreateZones < ActiveRecord::Migration
+  def change
+    create_table :zones do |t|
+      t.string :rachio_zone_id
+      t.integer :zone_number
+      t.string :name
+      t.boolean :enabled
+      t.references :device, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160508175824) do
+ActiveRecord::Schema.define(version: 20160509004155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20160508175824) do
     t.string   "api_key"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.string   "rachio_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160509004155) do
+ActiveRecord::Schema.define(version: 20160509190203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "devices", force: :cascade do |t|
+    t.string   "rachio_device_id"
+    t.string   "status"
+    t.boolean  "on"
+    t.string   "name"
+    t.integer  "user_id"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  add_index "devices", ["user_id"], name: "index_devices_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "username"
@@ -25,4 +37,18 @@ ActiveRecord::Schema.define(version: 20160509004155) do
     t.string   "rachio_id"
   end
 
+  create_table "zones", force: :cascade do |t|
+    t.string   "rachio_zone_id"
+    t.integer  "zone_number"
+    t.string   "name"
+    t.boolean  "enabled"
+    t.integer  "device_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "zones", ["device_id"], name: "index_zones_on_device_id", using: :btree
+
+  add_foreign_key "devices", "users"
+  add_foreign_key "zones", "devices"
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,23 +2,27 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::SessionsController, type: :controller do
   it "logs in a registered user" do
-    user_params = {user: {username: "user1", password: "password1", api_key: "1111"}}
-    User.create(user_params[:user])
+    VCR.use_cassette 'registered log in' do
+      user_params = {user: {username: "user1", password: "password1", api_key: "1111"}}
+      User.create(user_params[:user])
 
-    post :create, user_params
-    reply = JSON.parse(response.body)
+      post :create, user_params
+      reply = JSON.parse(response.body)
 
-    expect(reply["user"]["username"]).to eq "user1"
-    expect(response.status).to eq 200
+      expect(reply["user"]["username"]).to eq "user1"
+      expect(response.status).to eq 200
+    end
   end
 
   it "returns error message if user not registered" do
-    user_params = {user: {username: "user1", password: "password1", api_key: "1111"}}
+    VCR.use_cassette 'unregistered log in' do
+      user_params = {user: {username: "user1", password: "password1", api_key: "1111"}}
 
-    post :create, user_params
-    reply = response.body
+      post :create, user_params
+      reply = response.body
 
-    expect(reply).to eq "No user with given username and password found"
-    expect(response.status).to eq 400
+      expect(reply).to eq "No user with given username and password found"
+      expect(response.status).to eq 400
+    end
   end
 end

--- a/spec/features/user_logs_in_spec.rb
+++ b/spec/features/user_logs_in_spec.rb
@@ -2,19 +2,25 @@ require 'rails_helper'
 
 RSpec.feature "Log In", type: :feature do
   scenario "registered user in db logs in", js: true do
-    login("rachiobeta", "test1234")
+    VCR.use_cassette "registered log in" do
+      User.create(username: "rachiobeta", password: "test1234")
+      login("rachiobeta", "test1234")
 
-    expect(page).to have_content("Logged in as rachiobeta")
-    expect(page).to have_content("Logout")
-    expect(page).to_not have_content("Login")
+      expect(page).to have_content("Logged in as rachiobeta")
+      expect(page).to have_content("Logout")
+      expect(page).to_not have_content("Login")
+    end
   end
 
   scenario "logged in user refreshes still logged in", js: true do
-    login("rachiobeta", "test1234")
+    VCR.use_cassette "registered log in and refresh" do
+      User.create(username: "rachiobeta", password: "test1234")
+      login("rachiobeta", "test1234")
 
-    visit root_path
-    expect(page).to have_content("Logged in as rachiobeta")
-    expect(page).to have_content("Logout")
-    expect(page).to_not have_content("Login")
+      visit root_path
+      expect(page).to have_content("Logged in as rachiobeta")
+      expect(page).to have_content("Logout")
+      expect(page).to_not have_content("Login")
+    end
   end
 end

--- a/spec/features/user_logs_out_spec.rb
+++ b/spec/features/user_logs_out_spec.rb
@@ -2,12 +2,15 @@ require 'rails_helper'
 
 RSpec.feature "Log Out", type: :feature do
   scenario "logged in user logs out", js: true do
-    login("rachiobeta", "test1234")
+    VCR.use_cassette "log out" do
+      User.create(username: "rachiobeta", password: "test1234")
+      login("rachiobeta", "test1234")
 
-    click_on "Logout"
+      click_on "Logout"
 
-    expect(page).to_not have_content("Logged in as rachiobeta")
-    expect(page).to_not have_content("Logout")
-    expect(page).to have_content("Login")
+      expect(page).to_not have_content("Logged in as rachiobeta")
+      expect(page).to_not have_content("Logout")
+      expect(page).to have_content("Login")
+    end
   end
 end

--- a/spec/features/user_sees_devices_and_zones_spec.rb
+++ b/spec/features/user_sees_devices_and_zones_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature "User sees devices and zones", type: :feature do
+  scenario "registered user sees devices when logged in", js: true do
+    VCR.use_cassette "log in with devices" do
+      make_test_user
+      login("rachiobeta", "test1234")
+
+      expect(page).to have_content("c761bfa0-4c49-4b4f-8a79-04e42bea881a")
+      (1..8).each do |i|
+        expect(page).to have_content("Zone #{i}")
+      end
+    end
+  end
+end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Device, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe User, type: :model do
 
       expect(user.devices.count).to eq 0
 
-
       ras = RachioApiService.new(user)
       user.get_or_update_devices(ras)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "returns nil devices with illegal api_key" do
+    VCR.use_cassette 'illegal api_key' do
+      user = User.create(username: "a", password: "b")
+      ras = RachioApiService.new(user)
+      reply = user.get_or_update_devices(ras)
+      expect(reply).to eq nil
+    end
+  end
+
+  it "gets json devices with legal api_key" do
+    VCR.use_cassette 'legal api_key' do
+      user = make_test_user
+      ras = RachioApiService.new(user)
+      reply = user.get_or_update_devices(ras)
+      binding.pry
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,9 +13,17 @@ RSpec.describe User, type: :model do
   it "gets json devices with legal api_key" do
     VCR.use_cassette 'legal api_key' do
       user = make_test_user
+
+      expect(user.devices.count).to eq 0
+
+
       ras = RachioApiService.new(user)
-      reply = user.get_or_update_devices(ras)
-      binding.pry
+      user.get_or_update_devices(ras)
+
+      expect(user.devices.count).to eq 1
+      device = user.devices.first
+
+      expect(device.zones.count).to eq 8
     end
   end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Zone, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,3 +86,9 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/vcr'
+  c.ignore_hosts '127.0.0.1'
+  c.hook_into :webmock
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,12 +21,22 @@ RSpec.configure do |config|
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
   def login(username, password)
-    User.create(username: username, password: password)
+    User.find_or_create_by(username: username, password: password)
 
     visit root_path
     fill_in("username", with: username)
     fill_in("password", with: password)
     click_on "Login"
+  end
+
+
+
+  def make_test_user
+    username = ENV["rachio_test_username"]
+    password = ENV["rachio_test_password"]
+    user = User.create(username: username,
+                password: password,
+                  api_key: ENV["rachio_test_api_key"])
   end
 
   config.expect_with :rspec do |expectations|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,15 +21,11 @@ RSpec.configure do |config|
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
   def login(username, password)
-    User.find_or_create_by(username: username, password: password)
-
     visit root_path
     fill_in("username", with: username)
     fill_in("password", with: password)
     click_on "Login"
   end
-
-
 
   def make_test_user
     username = ENV["rachio_test_username"]

--- a/spec/vcr/illegal_api_key.yml
+++ b/spec/vcr/illegal_api_key.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 May 2016 19:26:51 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"The client is not authorized."}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:26:51 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/legal_api_key.yml
+++ b/spec/vcr/legal_api_key.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer c3667b81-92a6-4913-b83c-64cc713cbc1e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2016 19:26:52 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"61b28ce9-7bc1-47cc-9b85-98b6bebf8951"}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:26:51 GMT
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/61b28ce9-7bc1-47cc-9b85-98b6bebf8951
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer c3667b81-92a6-4913-b83c-64cc713cbc1e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2016 19:26:52 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '13870'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"61b28ce9-7bc1-47cc-9b85-98b6bebf8951","username":"rachiobeta","fullName":"Rachio
+        Beta","email":"beta@rach.io","devices":[{"id":"c761bfa0-4c49-4b4f-8a79-04e42bea881a","status":"ONLINE","zones":[{"id":"61197df9-d256-4959-8117-7625f919b2b3","zoneNumber":6,"name":"Zone
+        6","enabled":true,"customNozzle":{"name":"Rotor Head","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/rotor_head.png","category":"ROTOR_HEAD","inchesPerHour":1.0},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.7,"yardAreaSquareFeet":1000,"lastWateredDuration":11,"lastWateredDate":1462760287489,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":3359,"2":2799,"3":2239,"4":1679,"5":1120},"runtime":2239},{"id":"69c72b55-6418-461d-bd86-1f3eac38dbe2","zoneNumber":2,"name":"Zone
+        2","enabled":true,"customNozzle":{"name":"Emitter","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/emitter.png","category":"EMITTER","inchesPerHour":0.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Warm
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/warm_season_grass.png","coefficient":0.65},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":9.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":3543,"lastWateredDate":1462710613257,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.92,"depthOfWater":0.77,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":8847,"2":7372,"3":5898,"4":4423,"5":2949},"runtime":5898},{"id":"18a7b4a0-0b46-4096-aefe-569d48954cef","zoneNumber":7,"name":"Zone
+        7","enabled":true,"customNozzle":{"name":"Fixed Spray Head","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/fixed_spray.png","category":"FIXED_SPRAY_HEAD","inchesPerHour":1.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Warm
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/warm_season_grass.png","coefficient":0.65},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":9.0,"managementAllowedDepletion":0.5,"efficiency":0.8,"yardAreaSquareFeet":1000,"lastWateredDuration":1861,"lastWateredDate":1462720910068,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.92,"depthOfWater":0.77,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":3150,"2":2625,"3":2100,"4":1575,"5":1050},"runtime":2100},{"id":"5e78b7b7-c0c6-48e4-aab0-2504d4633564","zoneNumber":3,"name":"Zone
+        3","enabled":true,"customNozzle":{"name":"Rotary Nozzle","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/rotary_nozzle.png","category":"ROTARY_NOZZLE","inchesPerHour":0.7},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.8,"yardAreaSquareFeet":1000,"lastWateredDuration":2703,"lastWateredDate":1462713321102,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":4471,"2":3726,"3":2981,"4":2235,"5":1490},"runtime":2981},{"id":"5dba747c-ad3e-450e-bf85-5061ca3bdbd5","zoneNumber":5,"name":"Zone
+        5","enabled":true,"customNozzle":{"name":"Mister","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/mister.png","category":"MISTER","inchesPerHour":2.0},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"bf0e1c43-302e-431d-9c1a-92175e7c5c12","name":"Sand","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/sand.png","category":"SAND","infiltrationRate":0.6,"editable":false,"percentAvailableWater":1.64},"customSlope":{"name":"Slight","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/slight.png","variance":"FOUR_SIX","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Mostly
+        shade","description":"2 hours or less of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/mostly_shade.png","exposure":0.71},"availableWater":0.05,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":62,"lastWateredDate":1462804801943,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.18,"depthOfWater":0.15,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":431,"2":359,"3":287,"4":215,"5":144},"runtime":287},{"id":"4f1b562e-1dc3-40d7-acf1-2a1998a47786","zoneNumber":8,"name":"Zone
+        8","enabled":true,"customNozzle":{"name":"Fixed Spray Head","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/fixed_spray.png","category":"FIXED_SPRAY_HEAD","inchesPerHour":1.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.8,"yardAreaSquareFeet":1000,"lastWateredDuration":1264,"lastWateredDate":1462722179959,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":2086,"2":1739,"3":1391,"4":1043,"5":695},"runtime":1391},{"id":"ad9f83be-8a6c-47ad-af40-8300557c3355","zoneNumber":1,"name":"Zone
+        1","enabled":true,"customNozzle":{"name":"Bubbler","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/bubbler.png","category":"BUBBLER","inchesPerHour":1.0},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":62,"lastWateredDate":1462816783845,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":2930,"2":2441,"3":1953,"4":1465,"5":977},"runtime":1953},{"id":"b709ec48-8b6e-44c9-937d-1c1c82376fd2","zoneNumber":4,"name":"Zone
+        4","enabled":true,"customNozzle":{"name":"Emitter","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/emitter.png","category":"EMITTER","inchesPerHour":0.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":125,"lastWateredDate":1462805314345,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":5860,"2":4883,"3":3906,"4":2930,"5":1953},"runtime":3906}],"timeZone":"America/Denver","latitude":39.75352,"longitude":-104.9918,"zip":"80205","name":"Rachio
+        Test Device","scheduleRules":[{"id":"138042d5-c12b-48ed-8af0-5c347e4a2bb7","zones":[{"zoneId":"ad9f83be-8a6c-47ad-af40-8300557c3355","zoneNumber":1,"duration":1860,"sortOrder":1},{"zoneId":"4f1b562e-1dc3-40d7-acf1-2a1998a47786","zoneNumber":8,"duration":1260,"sortOrder":8},{"zoneId":"5e78b7b7-c0c6-48e4-aab0-2504d4633564","zoneNumber":3,"duration":2700,"sortOrder":3},{"zoneId":"5dba747c-ad3e-450e-bf85-5061ca3bdbd5","zoneNumber":5,"duration":300,"sortOrder":5},{"zoneId":"61197df9-d256-4959-8117-7625f919b2b3","zoneNumber":6,"duration":1860,"sortOrder":6},{"zoneId":"18a7b4a0-0b46-4096-aefe-569d48954cef","zoneNumber":7,"duration":1860,"sortOrder":7},{"zoneId":"b709ec48-8b6e-44c9-937d-1c1c82376fd2","zoneNumber":4,"duration":3540,"sortOrder":4},{"zoneId":"69c72b55-6418-461d-bd86-1f3eac38dbe2","zoneNumber":2,"duration":3540,"sortOrder":2}],"scheduleJobTypes":["INTERVAL_1"],"summary":"As
+        Needed at 5:00 AM","rainDelay":true,"waterBudget":true,"cycleSoakStatus":"ON","startDate":1462255200000,"name":"Water
+        all zones","enabled":true,"totalDuration":16920,"weatherIntelligenceSensitivity":0.125,"seasonalAdjustment":0.0,"totalDurationNoCycle":16920,"cycles":1,"cycleSoak":true,"externalName":"Water
+        all zones"},{"id":"68ed3df0-483e-4495-9c01-0944dad66911","zones":[{"zoneId":"61197df9-d256-4959-8117-7625f919b2b3","zoneNumber":6,"duration":300,"sortOrder":4},{"zoneId":"4f1b562e-1dc3-40d7-acf1-2a1998a47786","zoneNumber":8,"duration":300,"sortOrder":5},{"zoneId":"5dba747c-ad3e-450e-bf85-5061ca3bdbd5","zoneNumber":5,"duration":300,"sortOrder":3}],"scheduleJobTypes":["INTERVAL_3"],"summary":"Every
+        3 days at 5:00 am","rainDelay":true,"waterBudget":false,"cycleSoakStatus":"ON","startDate":1451505086480,"name":"Zone
+        5, Zone 6, Zone 8","enabled":false,"totalDuration":900,"weatherIntelligenceSensitivity":0.25,"seasonalAdjustment":0.0,"totalDurationNoCycle":900,"cycles":1,"cycleSoak":true,"externalName":"Zone
+        5, Zone 6, Zone 8"}],"serialNumber":"V31140320","rainDelayExpirationDate":1462808519000,"rainDelayStartDate":1462788195486,"macAddress":"0C2A690958B1","elevation":1588.32141113281,"webhooks":[],"paused":false,"on":true,"flexScheduleRules":[],"model":"8ZULW","scheduleModeType":"MANUAL","utcOffset":-21600000}],"enabled":true,"roles":[],"managedDevices":[],"displayUnit":"US"}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:26:51 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/log_in_with_devices.yml
+++ b/spec/vcr/log_in_with_devices.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer c3667b81-92a6-4913-b83c-64cc713cbc1e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2016 22:12:56 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"61b28ce9-7bc1-47cc-9b85-98b6bebf8951"}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 22:12:57 GMT
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/61b28ce9-7bc1-47cc-9b85-98b6bebf8951
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer c3667b81-92a6-4913-b83c-64cc713cbc1e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2016 22:12:57 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '13870'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"61b28ce9-7bc1-47cc-9b85-98b6bebf8951","username":"rachiobeta","fullName":"Rachio
+        Beta","email":"beta@rach.io","devices":[{"id":"c761bfa0-4c49-4b4f-8a79-04e42bea881a","status":"ONLINE","zones":[{"id":"18a7b4a0-0b46-4096-aefe-569d48954cef","zoneNumber":7,"name":"Zone
+        7","enabled":true,"customNozzle":{"name":"Fixed Spray Head","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/fixed_spray.png","category":"FIXED_SPRAY_HEAD","inchesPerHour":1.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Warm
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/warm_season_grass.png","coefficient":0.65},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":9.0,"managementAllowedDepletion":0.5,"efficiency":0.8,"yardAreaSquareFeet":1000,"lastWateredDuration":1861,"lastWateredDate":1462720910068,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.92,"depthOfWater":0.77,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":3150,"2":2625,"3":2100,"4":1575,"5":1050},"runtime":2100},{"id":"b709ec48-8b6e-44c9-937d-1c1c82376fd2","zoneNumber":4,"name":"Zone
+        4","enabled":true,"customNozzle":{"name":"Emitter","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/emitter.png","category":"EMITTER","inchesPerHour":0.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":125,"lastWateredDate":1462805314345,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":5860,"2":4883,"3":3906,"4":2930,"5":1953},"runtime":3906},{"id":"5e78b7b7-c0c6-48e4-aab0-2504d4633564","zoneNumber":3,"name":"Zone
+        3","enabled":true,"customNozzle":{"name":"Rotary Nozzle","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/rotary_nozzle.png","category":"ROTARY_NOZZLE","inchesPerHour":0.7},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.8,"yardAreaSquareFeet":1000,"lastWateredDuration":2703,"lastWateredDate":1462713321102,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":4471,"2":3726,"3":2981,"4":2235,"5":1490},"runtime":2981},{"id":"69c72b55-6418-461d-bd86-1f3eac38dbe2","zoneNumber":2,"name":"Zone
+        2","enabled":true,"customNozzle":{"name":"Emitter","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/emitter.png","category":"EMITTER","inchesPerHour":0.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Warm
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/warm_season_grass.png","coefficient":0.65},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":9.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":3543,"lastWateredDate":1462710613257,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.92,"depthOfWater":0.77,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":8847,"2":7372,"3":5898,"4":4423,"5":2949},"runtime":5898},{"id":"ad9f83be-8a6c-47ad-af40-8300557c3355","zoneNumber":1,"name":"Zone
+        1","enabled":true,"customNozzle":{"name":"Bubbler","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/bubbler.png","category":"BUBBLER","inchesPerHour":1.0},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":62,"lastWateredDate":1462826276055,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":2930,"2":2441,"3":1953,"4":1465,"5":977},"runtime":1953},{"id":"5dba747c-ad3e-450e-bf85-5061ca3bdbd5","zoneNumber":5,"name":"Zone
+        5","enabled":true,"customNozzle":{"name":"Mister","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/mister.png","category":"MISTER","inchesPerHour":2.0},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"bf0e1c43-302e-431d-9c1a-92175e7c5c12","name":"Sand","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/sand.png","category":"SAND","infiltrationRate":0.6,"editable":false,"percentAvailableWater":1.64},"customSlope":{"name":"Slight","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/slight.png","variance":"FOUR_SIX","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Mostly
+        shade","description":"2 hours or less of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/mostly_shade.png","exposure":0.71},"availableWater":0.05,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.9,"yardAreaSquareFeet":1000,"lastWateredDuration":62,"lastWateredDate":1462804801943,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.18,"depthOfWater":0.15,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":431,"2":359,"3":287,"4":215,"5":144},"runtime":287},{"id":"61197df9-d256-4959-8117-7625f919b2b3","zoneNumber":6,"name":"Zone
+        6","enabled":true,"customNozzle":{"name":"Rotor Head","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/rotor_head.png","category":"ROTOR_HEAD","inchesPerHour":1.0},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.7,"yardAreaSquareFeet":1000,"lastWateredDuration":11,"lastWateredDate":1462760287489,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":3359,"2":2799,"3":2239,"4":1679,"5":1120},"runtime":2239},{"id":"4f1b562e-1dc3-40d7-acf1-2a1998a47786","zoneNumber":8,"name":"Zone
+        8","enabled":true,"customNozzle":{"name":"Fixed Spray Head","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/nozzle/fixed_spray.png","category":"FIXED_SPRAY_HEAD","inchesPerHour":1.5},"customSoil":{"createDate":1441831272323,"lastUpdateDate":1441831272323,"id":"1f9240e5-ba87-4b88-b828-a5f456f399b7","name":"Loam","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/soil/loam.png","category":"LOAM","infiltrationRate":0.35,"editable":false,"percentAvailableWater":0.7},"customSlope":{"name":"Flat","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/slope/flat.png","variance":"ZERO_THREE","sortOrder":0},"customCrop":{"name":"Cool
+        Season Grass","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/crop/cool_season_grass.png","coefficient":0.7},"customShade":{"name":"Lots
+        of sun","description":"6-8 hours of sun","imageUrl":"https://s3-us-west-2.amazonaws.com/rachio-api-icons/shade/lots_of_sun.png","exposure":1.0},"availableWater":0.17,"rootZoneDepth":6.0,"managementAllowedDepletion":0.5,"efficiency":0.8,"yardAreaSquareFeet":1000,"lastWateredDuration":1264,"lastWateredDate":1462722179959,"scheduleDataModified":false,"fixedRuntime":0,"saturatedDepthOfWater":0.61,"depthOfWater":0.51,"maxRuntime":10800,"wateringAdjustmentRuntimes":{"1":2086,"2":1739,"3":1391,"4":1043,"5":695},"runtime":1391}],"timeZone":"America/Denver","latitude":39.75352,"longitude":-104.9918,"zip":"80205","name":"Rachio
+        Test Device","scheduleRules":[{"id":"138042d5-c12b-48ed-8af0-5c347e4a2bb7","zones":[{"zoneId":"ad9f83be-8a6c-47ad-af40-8300557c3355","zoneNumber":1,"duration":1860,"sortOrder":1},{"zoneId":"4f1b562e-1dc3-40d7-acf1-2a1998a47786","zoneNumber":8,"duration":1260,"sortOrder":8},{"zoneId":"5e78b7b7-c0c6-48e4-aab0-2504d4633564","zoneNumber":3,"duration":2700,"sortOrder":3},{"zoneId":"5dba747c-ad3e-450e-bf85-5061ca3bdbd5","zoneNumber":5,"duration":300,"sortOrder":5},{"zoneId":"61197df9-d256-4959-8117-7625f919b2b3","zoneNumber":6,"duration":1860,"sortOrder":6},{"zoneId":"18a7b4a0-0b46-4096-aefe-569d48954cef","zoneNumber":7,"duration":1860,"sortOrder":7},{"zoneId":"b709ec48-8b6e-44c9-937d-1c1c82376fd2","zoneNumber":4,"duration":3540,"sortOrder":4},{"zoneId":"69c72b55-6418-461d-bd86-1f3eac38dbe2","zoneNumber":2,"duration":3540,"sortOrder":2}],"scheduleJobTypes":["INTERVAL_1"],"summary":"As
+        Needed at 5:00 AM","rainDelay":true,"waterBudget":true,"cycleSoakStatus":"ON","startDate":1462255200000,"name":"Water
+        all zones","enabled":true,"totalDuration":16920,"weatherIntelligenceSensitivity":0.125,"seasonalAdjustment":0.0,"totalDurationNoCycle":16920,"cycles":1,"externalName":"Water
+        all zones","cycleSoak":true},{"id":"68ed3df0-483e-4495-9c01-0944dad66911","zones":[{"zoneId":"61197df9-d256-4959-8117-7625f919b2b3","zoneNumber":6,"duration":300,"sortOrder":4},{"zoneId":"4f1b562e-1dc3-40d7-acf1-2a1998a47786","zoneNumber":8,"duration":300,"sortOrder":5},{"zoneId":"5dba747c-ad3e-450e-bf85-5061ca3bdbd5","zoneNumber":5,"duration":300,"sortOrder":3}],"scheduleJobTypes":["INTERVAL_3"],"summary":"Every
+        3 days at 5:00 am","rainDelay":true,"waterBudget":false,"cycleSoakStatus":"ON","startDate":1451505086480,"name":"Zone
+        5, Zone 6, Zone 8","enabled":false,"totalDuration":900,"weatherIntelligenceSensitivity":0.25,"seasonalAdjustment":0.0,"totalDurationNoCycle":900,"cycles":1,"externalName":"Zone
+        5, Zone 6, Zone 8","cycleSoak":true}],"serialNumber":"V31140320","rainDelayExpirationDate":1462808519000,"rainDelayStartDate":1462788195486,"macAddress":"0C2A690958B1","elevation":1588.32141113281,"webhooks":[],"paused":false,"on":true,"flexScheduleRules":[],"model":"8ZULW","scheduleModeType":"MANUAL","utcOffset":-21600000}],"enabled":true,"roles":[],"managedDevices":[],"displayUnit":"US"}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 22:12:57 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/log_out.yml
+++ b/spec/vcr/log_out.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 May 2016 19:43:20 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"The client is not authorized."}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:43:20 GMT
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 May 2016 19:43:20 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"The client is not authorized."}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:43:20 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/registered_log_in.yml
+++ b/spec/vcr/registered_log_in.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 May 2016 19:43:19 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"The client is not authorized."}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:43:18 GMT
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 May 2016 19:43:19 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"The client is not authorized."}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:43:18 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/registered_log_in_and_refresh.yml
+++ b/spec/vcr/registered_log_in_and_refresh.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 May 2016 19:46:56 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"The client is not authorized."}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:46:56 GMT
+- request:
+    method: get
+    uri: https://api.rach.io/1/public/person/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.rach.io
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 09 May 2016 19:46:57 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"The client is not authorized."}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 19:46:56 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
This branch implements a rachioApiService for communicating with the Rachio API.  We opted to implement a user's devices (and their zones) in the database, so that page refreshes would not require additional API calls. When a user logs in, a single API call is made to get all of the device data and is loaded into the DB.  That information is served up via AJAX to the main react component, which trickles it down to the rachioDashboard, Devices, and Zone components.  On refresh, the same info is gathered from the DB and served up via the index action of the rachio controller again to the main react component.  This functionality is tested at the feature, controller, and unit levels.
